### PR TITLE
Fix: remove deprecated subplot() use

### DIFF
--- a/control/freqplot.py
+++ b/control/freqplot.py
@@ -135,6 +135,20 @@ def bode_plot(syslist, omega=None, dB=None, Hz=None, deg=None,
             else:
                 omega = sp.logspace(np.log10(omega_limits[0]), np.log10(omega_limits[1]), endpoint=True)
 
+    if Plot:
+        fig = plt.gcf()
+        ax_mag = None
+        ax_phase = None
+        for ax in fig.axes:
+            if ax.get_label() == 'pycontrol-bode-mag':
+                ax_mag = ax
+            elif ax.get_label() == 'pycontrol-bode-phs':
+                ax_phase = ax
+        if ax_mag is None or ax_phase is None:
+            plt.clf()
+            ax_mag = plt.subplot(211, label = 'pycontrol-bode-mag')
+            ax_phase = plt.subplot(212, label = 'pycontrol-bode-phs', sharex=ax_mag)
+
     mags, phases, omegas, nyquistfrqs = [], [], [], []
     for sys in syslist:
         if (sys.inputs > 1 or sys.outputs > 1):
@@ -172,7 +186,6 @@ def bode_plot(syslist, omega=None, dB=None, Hz=None, deg=None,
 
             if (Plot):
                 # Magnitude plot
-                ax_mag = plt.subplot(211);
                 if dB:
                     pltline = ax_mag.semilogx(omega_plot, 20 * np.log10(mag), *args, **kwargs)
                 else:
@@ -186,7 +199,6 @@ def bode_plot(syslist, omega=None, dB=None, Hz=None, deg=None,
                 ax_mag.set_ylabel("Magnitude (dB)" if dB else "Magnitude")
 
                 # Phase plot
-                ax_phase = plt.subplot(212, sharex=ax_mag);
                 if deg:
                     phase_plot = phase * 180. / math.pi
                 else:
@@ -354,27 +366,44 @@ def gangof4_plot(P, C, omega=None):
         S = feedback(1, L);
         T = L * S;
 
+        plot_axes = {'t' : None, 's' : None, 'ps' : None, 'cs' : None}
+        for ax in plt.gcf().axes:
+            label = ax.get_label()
+            if label.startswith('pycontrol-gof-'):
+                key = label[len('pycontrol-gof-'):]
+                if key not in plot_axes:
+                    raise RuntimeError("unknown gof axis type '{}'".format(label))
+                plot_axes[key] = ax
+
+        # if any are missing, start from scratch
+        if any((ax is None for ax in plot_axes.values())):
+            plt.clf()
+            plot_axes = {'t' : plt.subplot(221,label='pycontrol-gof-t'),
+                         'ps' : plt.subplot(222,label='pycontrol-gof-ps'),
+                         'cs' : plt.subplot(223,label='pycontrol-gof-cs'),
+                         's' : plt.subplot(224,label='pycontrol-gof-s')}
+
         # Plot the four sensitivity functions
         #! TODO: Need to add in the mag = 1 lines
         mag_tmp, phase_tmp, omega = T.freqresp(omega);
         mag = np.squeeze(mag_tmp)
         phase = np.squeeze(phase_tmp)
-        plt.subplot(221); plt.loglog(omega, mag);
+        plot_axes['t'].loglog(omega, mag);
 
         mag_tmp, phase_tmp, omega = (P * S).freqresp(omega);
         mag = np.squeeze(mag_tmp)
         phase = np.squeeze(phase_tmp)
-        plt.subplot(222); plt.loglog(omega, mag);
+        plot_axes['ps'].loglog(omega, mag);
 
         mag_tmp, phase_tmp, omega = (C * S).freqresp(omega);
         mag = np.squeeze(mag_tmp)
         phase = np.squeeze(phase_tmp)
-        plt.subplot(223); plt.loglog(omega, mag);
+        plot_axes['cs'].loglog(omega, mag);
 
         mag_tmp, phase_tmp, omega = S.freqresp(omega);
         mag = np.squeeze(mag_tmp)
         phase = np.squeeze(phase_tmp)
-        plt.subplot(224); plt.loglog(omega, mag);
+        plot_axes['s'].loglog(omega, mag);
 
 #
 # Utility functions


### PR DESCRIPTION
Sub-axes are created with specific axis labels, which are strings;
the Bode plot uses 'pycontrol-bode-{mag,phs}', and the gang-of-four
plot uses 'pycontrol-gof-{t,s,ps,cs}' to identify its plots.

These axes are then used, if possible; if not, the figure is cleared
and the set of axes created.