### PR TITLE
remove matrix keyword in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ jobs:
       python: "3.8"
       env: SCIPY=scipy SLYCOT=source
 
-matrix:
   # Exclude combinations that are very unlikely (and don't work)
   exclude:
     - python: "3.7"            # python3.7 should use latest scipy


### PR DESCRIPTION
When you remove `matrix:` an put it into the same `jobs:` as the `include` section, the `allowed_failures` jobs are run.